### PR TITLE
SATD improve

### DIFF
--- a/common/ppc/pixel.c
+++ b/common/ppc/pixel.c
@@ -137,7 +137,6 @@ static ALWAYS_INLINE vec_s32_t add_abs_4( vec_s16_t a, vec_s16_t b,
 static int pixel_satd_4x4_altivec( uint8_t *pix1, intptr_t i_pix1,
                                    uint8_t *pix2, intptr_t i_pix2 )
 {
-    ALIGNED_16( int i_satd );
 
     PREP_DIFF;
     vec_s16_t diff0v, diff1v, diff2v, diff3v;
@@ -160,10 +159,7 @@ static int pixel_satd_4x4_altivec( uint8_t *pix1, intptr_t i_pix1,
                  temp0v, temp1v, temp2v, temp3v );
 
     satdv = add_abs_4( temp0v, temp1v, temp2v, temp3v );
-
-    satdv = vec_sum2s( satdv, zero_s32v );
-    satdv = vec_splat( satdv, 1 );
-    vec_ste( satdv, 0, &i_satd );
+    int i_satd =  vec_extract(satdv,0) + vec_extract(satdv,1);
 
     return i_satd >> 1;
 }
@@ -206,10 +202,7 @@ static int pixel_satd_4x8_altivec( uint8_t *pix1, intptr_t i_pix1,
                  temp0v, temp1v, temp2v, temp3v );
 
     satdv = vec_add( satdv, add_abs_4( temp0v, temp1v, temp2v, temp3v ) );
-
-    satdv = vec_sum2s( satdv, zero_s32v );
-    satdv = vec_splat( satdv, 1 );
-    vec_ste( satdv, 0, &i_satd );
+    i_satd =  vec_extract(satdv,0) + vec_extract(satdv,1);
 
     return i_satd >> 1;
 }
@@ -280,9 +273,7 @@ static int pixel_satd_8x4_altivec( uint8_t *pix1, intptr_t i_pix1,
     satdv = add_abs_8( temp0v, temp1v, temp2v, temp3v,
                        temp4v, temp5v, temp6v, temp7v );
 
-    satdv = vec_sum2s( satdv, zero_s32v );
-    satdv = vec_splat( satdv, 1 );
-    vec_ste( satdv, 0, &i_satd );
+    i_satd =  vec_extract(satdv,0) + vec_extract(satdv,1);
 
     return i_satd >> 1;
 }
@@ -330,8 +321,7 @@ static int pixel_satd_8x8_altivec( uint8_t *pix1, intptr_t i_pix1,
                        temp4v, temp5v, temp6v, temp7v );
 
     satdv = vec_sums( satdv, zero_s32v );
-    satdv = vec_splat( satdv, 3 );
-    vec_ste( satdv, 0, &i_satd );
+    i_satd =  vec_extract(satdv,3) ;
 
     return i_satd >> 1;
 }
@@ -400,8 +390,7 @@ static int pixel_satd_8x16_altivec( uint8_t *pix1, intptr_t i_pix1,
                                        temp4v, temp5v, temp6v, temp7v ) );
 
     satdv = vec_sums( satdv, zero_s32v );
-    satdv = vec_splat( satdv, 3 );
-    vec_ste( satdv, 0, &i_satd );
+    i_satd =  vec_extract(satdv,3) ;
 
     return i_satd >> 1;
 }

--- a/common/ppc/pixel.c
+++ b/common/ppc/pixel.c
@@ -564,8 +564,7 @@ static int pixel_satd_16x16_altivec( uint8_t *pix1, intptr_t i_pix1,
                                        temp4v, temp5v, temp6v, temp7v ) );
 
     satdv = vec_sums( satdv, zero_s32v );
-    satdv = vec_splat( satdv, 3 );
-    vec_ste( satdv, 0, &i_satd );
+    i_satd =  vec_extract(satdv,3) ;
 
     return i_satd >> 1;
 }

--- a/common/ppc/pixel.c
+++ b/common/ppc/pixel.c
@@ -459,8 +459,8 @@ static int pixel_satd_16x8_altivec( uint8_t *pix1, intptr_t i_pix1,
                                        temp4v, temp5v, temp6v, temp7v ) );
 
     satdv = vec_sums( satdv, zero_s32v );
-    satdv = vec_splat( satdv, 3 );
-    vec_ste( satdv, 0, &i_satd );
+
+    i_satd =  vec_extract(satdv,3) ;
 
     return i_satd >> 1;
 }


### PR DESCRIPTION
Improve satd and intra_satd_x3 by using vec_extract instead of vec_splat and vec_ste:

**Power 8:**
satd_4x4_altivec: 148 ==> satd_4x4_altivec: 87
satd_4x8_altivec: 186 ==> satd_4x8_altivec: 128
satd_8x4_altivec: 177 ==> satd_8x4_altivec: 114
satd_8x8_altivec: 188 ==> satd_8x8_altivec: 136
satd_8x16_altivec: 300 ==> satd_8x16_altivec: 262
satd_16x8_altivec: 269 ==> satd_16x8_altivec: 271
satd_16x16_altivec: 517 ==> satd_16x16_altivec: 485
intra_satd_x3_4x4_altivec: 528  ==> intra_satd_x3_4x4_altivec: 444 
intra_satd_x3_8x8c_altivec: 679 ==> intra_satd_x3_8x8c_altivec: 593
intra_satd_x3_16x16_altivec: 1815 ==> intra_satd_x3_16x16_altivec: 1724

**Power 9:**
satd_4x4_altivec: 131 ==> satd_4x4_altivec: 113
satd_4x8_altivec: 175 ==> satd_4x8_altivec: 156
satd_8x4_altivec: 150 ==> satd_8x4_altivec: 135
satd_8x8_altivec: 174 ==> satd_8x8_altivec: 161
satd_8x16_altivec: 290 ==> satd_8x16_altivec: 277
satd_16x8_altivec: 272 ==> satd_16x8_altivec: 272
satd_16x16_altivec: 563 ==> satd_16x16_altivec: 566
intra_satd_x3_4x4_altivec: 424 ==> intra_satd_x3_4x4_altivec: 400
intra_satd_x3_8x8c_altivec: 687 ==> intra_satd_x3_8x8c_altivec: 616
intra_satd_x3_16x16_altivec: 2047 ==> intra_satd_x3_16x16_altivec: 2062
