### PR TITLE
PPC: Improve zigzag_scan_4x4_field on Power9 by disabling the vec_perm.

### DIFF
--- a/common/ppc/dct.c
+++ b/common/ppc/dct.c
@@ -607,6 +607,7 @@ void x264_zigzag_scan_4x4_field_altivec( int16_t level[16], int16_t dct[16] )
     dct0v = vec_ld(0x00, dct);
     dct1v = vec_ld(0x10, dct);
 
+#ifndef __POWER9_VECTOR__
     const vec_u8_t sel0 = (vec_u8_t) CV(0,1,2,3,8,9,4,5,6,7,10,11,12,13,14,15);
 
     tmp0v = vec_perm( dct0v, dct1v, sel0 );
@@ -614,6 +615,14 @@ void x264_zigzag_scan_4x4_field_altivec( int16_t level[16], int16_t dct[16] )
 
     vec_st( tmp0v, 0x00, level );
     vec_st( tmp1v, 0x10, level );
+
+#else
+    vec_st( dct0v, 0x00, level );
+    vec_st( dct1v, 0x10, level );
+
+    * (uint32_t *) &level[3] = * (uint32_t *) &dct[2];
+    level[2] = dct[4];
+#endif
 }
 
 void x264_zigzag_scan_8x8_frame_altivec( int16_t level[64], int16_t dct[64] )


### PR DESCRIPTION
Checkasm8 --bench on Power9:
zigzag_scan_4x4_field_c: 56
Old: zigzag_scan_4x4_field_altivec: 52
New: zigzag_scan_4x4_field_altivec: 49

Performance in power8 is better when using vec_perm compared with the introduced code.

