### PR TITLE
Fix memory leaks

### DIFF
--- a/filters/video/source.c
+++ b/filters/video/source.c
@@ -44,8 +44,10 @@ static int init( hnd_t *handle, cli_vid_filter_t *filter, video_info_t *info, x2
         return -1;
     h->cur_frame = -1;
 
-    if( cli_input.picture_alloc( &h->pic, *handle, info->csp, info->width, info->height ) )
+    if( cli_input.picture_alloc( &h->pic, *handle, info->csp, info->width, info->height ) ) {
+        free(h);
         return -1;
+    }
 
     h->hin = *handle;
     *handle = h;

--- a/input/avs.c
+++ b/input/avs.c
@@ -270,6 +270,7 @@ static int open_file( char *psz_filename, hnd_t *p_handle, video_info_t *info, c
     if( h->func.avs_get_error )
     {
         const char *error = h->func.avs_get_error( h->env );
+        free(h);
         FAIL_IF_ERROR( error, "%s\n", error );
     }
     float avs_version = get_avs_version( h );

--- a/input/timecode.c
+++ b/input/timecode.c
@@ -380,6 +380,7 @@ static int open_file( char *psz_filename, hnd_t *p_handle, video_info_t *info, c
     {
         if( h->pts )
             free( h->pts );
+        free(h);
         fclose( tcfile_in );
         return -1;
     }

--- a/output/matroska_ebml.c
+++ b/output/matroska_ebml.c
@@ -308,6 +308,7 @@ mk_writer *mk_create_writer( const char *filename )
     if( !w->fp )
     {
         mk_destroy_contexts( w );
+        free( w->root );
         free( w );
         return NULL;
     }


### PR DESCRIPTION
There are more leaks, including a file handle leak, largely around FAIL_IF..  macros and thus uglier to fix.  Perhaps a RETURN_AND_FREE_IF_ERR in x264cli.h is the right solution.

We could also just turn on the static analysis for this repo to catch these issues in any PR going forward (specifically, https://muse.dev - free for open source).  Let me know and I can send over the activation if desired.