### PR TITLE
Add a muse configuration to install nasm build dep

### DIFF
--- a/.muse/config
+++ b/.muse/config
@@ -1,0 +1,1 @@
+setup = ".muse/setup.sh"

--- a/.muse/setup.sh
+++ b/.muse/setup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+apt update && apt install -y nasm


### PR DESCRIPTION
The `nasm` build dependency is not part of the standard https://muse.dev image.  This PR adds a trivial configuration to install nasm prior to build for code analysis.